### PR TITLE
Debug multiple requests to auto increment reserve

### DIFF
--- a/src/core_modules/capture-core/metaDataMemoryStoreBuilders/programs/factory/enrollment/EnrollmentFactory.js
+++ b/src/core_modules/capture-core/metaDataMemoryStoreBuilders/programs/factory/enrollment/EnrollmentFactory.js
@@ -310,14 +310,21 @@ export class EnrollmentFactory {
                     });
                 } else if (cachedProgramSections) {
                     // $FlowFixMe
-                    cachedProgramSections.asyncForEach(async (programSection) => {
-                        section = await this._buildSection(
+                    const sectionPromises = cachedProgramSections.map(programSection =>
+                        this._buildSection(
                             programSection.trackedEntityAttributes.map(id => trackedEntityAttributeDictionary[id]),
                             programSection.displayFormName,
                             programSection.id,
                             programSection.displayDescription,
-                        );
-                        section && enrollmentForm.addSection(section);
+                        ),
+                    );
+
+                    const sections = await Promise.all(sectionPromises);
+
+                    sections.forEach((sectionToAdd) => {
+                        if (sectionToAdd) {
+                            enrollmentForm.addSection(sectionToAdd);
+                        }
                     });
                 }
             }

--- a/src/core_modules/capture-core/metaDataMemoryStoreBuilders/programs/factory/enrollment/EnrollmentFactory.js
+++ b/src/core_modules/capture-core/metaDataMemoryStoreBuilders/programs/factory/enrollment/EnrollmentFactory.js
@@ -310,21 +310,14 @@ export class EnrollmentFactory {
                     });
                 } else if (cachedProgramSections) {
                     // $FlowFixMe
-                    const sectionPromises = cachedProgramSections.map(programSection =>
-                        this._buildSection(
+                    await cachedProgramSections.asyncForEach(async (programSection) => {
+                        section = await this._buildSection(
                             programSection.trackedEntityAttributes.map(id => trackedEntityAttributeDictionary[id]),
                             programSection.displayFormName,
                             programSection.id,
                             programSection.displayDescription,
-                        ),
-                    );
-
-                    const sections = await Promise.all(sectionPromises);
-
-                    sections.forEach((sectionToAdd) => {
-                        if (sectionToAdd) {
-                            enrollmentForm.addSection(sectionToAdd);
-                        }
+                        );
+                        section && enrollmentForm.addSection(section);
                     });
                 }
             }


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #8698cwgjh [multiple requests to auto increment reserve](https://app.clickup.com/t/8698cwgjh)

The problem happens when you have at least one section in the registration form of the attribute programs and "First stage appears on registration page" enabled

### :memo: Implementation
- Ensuring that promises are resolved in sequence and all program sections are available from the beginning

What was the problem?
1. When `buildEnrollmentForm` the `cachedProgramSections` are added using `asyncForEach` and asyncForEach does not correctly wait for the asynchronous functions within it to finish before continuing the program flow
2. In some point of the execution we have 0 attribute sections after calling `buildEnrollmentForm` and some checks are done taking into  account the number of sections. Then the request of generate is called.
3. After some time, we finally have the 2 attribute sections and it does again the checks according to the size, then the program stage section is added and the generate request is called again.

### :video_camera: Screenshots/Screen capture

[Screencast from 2025-03-26 10-23-06.webm](https://github.com/user-attachments/assets/882aeade-29e6-4bfc-b5d5-33af3c2e039b)

### :fire: Notes to the tester
- Follow the steps in the task video
