### PR TITLE
[SP] feat: honor TEA read sharing setting in WidgetProfile and Edit form

### DIFF
--- a/src/core_modules/capture-core/components/WidgetProfile/DataEntry/FormFoundation/DataElement.js
+++ b/src/core_modules/capture-core/components/WidgetProfile/DataEntry/FormFoundation/DataElement.js
@@ -197,7 +197,7 @@ const setBaseProperties = async ({
     dataElement.description = trackedEntityAttribute.description;
     dataElement.displayInForms = true;
     dataElement.displayInReports = programTrackedEntityAttribute.displayInList;
-    dataElement.disabled = trackedEntityAttribute.access?.write === false;
+    dataElement.disabled = false;
     dataElement.type = trackedEntityAttribute.valueType;
     dataElement.searchable = programTrackedEntityAttribute.searchable;
 

--- a/src/core_modules/capture-core/components/WidgetProfile/DataEntry/FormFoundation/DataElement.js
+++ b/src/core_modules/capture-core/components/WidgetProfile/DataEntry/FormFoundation/DataElement.js
@@ -197,7 +197,7 @@ const setBaseProperties = async ({
     dataElement.description = trackedEntityAttribute.description;
     dataElement.displayInForms = true;
     dataElement.displayInReports = programTrackedEntityAttribute.displayInList;
-    dataElement.disabled = false;
+    dataElement.disabled = trackedEntityAttribute.access?.write === false;
     dataElement.type = trackedEntityAttribute.valueType;
     dataElement.searchable = programTrackedEntityAttribute.searchable;
 
@@ -337,6 +337,10 @@ export const buildDataElement = (
                 programTrackedEntityAttribute,
             }),
         );
+        return null;
+    }
+
+    if (trackedEntityAttribute.access?.read === false) {
         return null;
     }
 

--- a/src/core_modules/capture-core/components/WidgetProfile/DataEntry/FormFoundation/types.js
+++ b/src/core_modules/capture-core/components/WidgetProfile/DataEntry/FormFoundation/types.js
@@ -55,6 +55,10 @@ export type TrackedEntityAttribute = {
     unique: ?boolean,
     orgunitScope: ?boolean,
     pattern: ?string,
+    access?: ?{
+        read?: ?boolean,
+        write?: ?boolean,
+    },
 };
 
 export type ProgramTrackedEntityAttribute = {

--- a/src/core_modules/capture-core/components/WidgetProfile/DataEntry/FormFoundation/types.js
+++ b/src/core_modules/capture-core/components/WidgetProfile/DataEntry/FormFoundation/types.js
@@ -57,7 +57,6 @@ export type TrackedEntityAttribute = {
     pattern: ?string,
     access?: ?{
         read?: ?boolean,
-        write?: ?boolean,
     },
 };
 

--- a/src/core_modules/capture-core/components/WidgetProfile/hooks/useApiProgram.js
+++ b/src/core_modules/capture-core/components/WidgetProfile/hooks/useApiProgram.js
@@ -15,7 +15,7 @@ const fields =
         'programStageSections[id,displayName,displayDescription,sortOrder,dataElements[id]],' +
         'programStageDataElements[compulsory,displayInReports,renderOptionsAsRadio,allowFutureDate,renderType[*],dataElement[id,displayName,displayShortName,displayFormName,valueType,translations[*],description,optionSetValue,style,optionSet[id,displayName,version,valueType,options[id,displayName,code,style, translations]]]]' +
     '],' +
-    'programTrackedEntityAttributes[trackedEntityAttribute[id,displayName,displayShortName,displayFormName,description,valueType,optionSetValue,unique,orgunitScope,pattern,translations[property,locale,value],optionSet[id,displayName,version,valueType,options[id,displayName,name,code,style,translations]]],displayInList,searchable,mandatory,renderOptionsAsRadio,allowFutureDate],' +
+    'programTrackedEntityAttributes[trackedEntityAttribute[id,displayName,displayShortName,displayFormName,description,valueType,optionSetValue,unique,orgunitScope,pattern,translations[property,locale,value],optionSet[id,displayName,version,valueType,options[id,displayName,name,code,style,translations]],access[read,write]],displayInList,searchable,mandatory,renderOptionsAsRadio,allowFutureDate],' +
     'trackedEntityType[id,access,displayName,allowAuditLog,minAttributesRequiredToSearch,featureType,trackedEntityTypeAttributes[trackedEntityAttribute[id],displayInList,mandatory,searchable],translations[property,locale,value]],' +
     'userRoles[id,displayName]';
 

--- a/src/core_modules/capture-core/components/WidgetProfile/hooks/useApiProgram.js
+++ b/src/core_modules/capture-core/components/WidgetProfile/hooks/useApiProgram.js
@@ -15,7 +15,7 @@ const fields =
         'programStageSections[id,displayName,displayDescription,sortOrder,dataElements[id]],' +
         'programStageDataElements[compulsory,displayInReports,renderOptionsAsRadio,allowFutureDate,renderType[*],dataElement[id,displayName,displayShortName,displayFormName,valueType,translations[*],description,optionSetValue,style,optionSet[id,displayName,version,valueType,options[id,displayName,code,style, translations]]]]' +
     '],' +
-    'programTrackedEntityAttributes[trackedEntityAttribute[id,displayName,displayShortName,displayFormName,description,valueType,optionSetValue,unique,orgunitScope,pattern,translations[property,locale,value],optionSet[id,displayName,version,valueType,options[id,displayName,name,code,style,translations]],access[read,write]],displayInList,searchable,mandatory,renderOptionsAsRadio,allowFutureDate],' +
+    'programTrackedEntityAttributes[trackedEntityAttribute[id,displayName,displayShortName,displayFormName,description,valueType,optionSetValue,unique,orgunitScope,pattern,translations[property,locale,value],optionSet[id,displayName,version,valueType,options[id,displayName,name,code,style,translations]],access[read]],displayInList,searchable,mandatory,renderOptionsAsRadio,allowFutureDate],' +
     'trackedEntityType[id,access,displayName,allowAuditLog,minAttributesRequiredToSearch,featureType,trackedEntityTypeAttributes[trackedEntityAttribute[id],displayInList,mandatory,searchable],translations[property,locale,value]],' +
     'userRoles[id,displayName]';
 

--- a/src/core_modules/capture-core/components/WidgetProfile/hooks/useClientAttributesWithSubvalues.js
+++ b/src/core_modules/capture-core/components/WidgetProfile/hooks/useClientAttributesWithSubvalues.js
@@ -21,6 +21,10 @@ type InputProgramData = {
             },
             valueType: string,
             unique: boolean,
+            access?: ?{
+                read?: ?boolean,
+                write?: ?boolean,
+            }
         },
         displayInList: boolean,
     }>,
@@ -53,8 +57,11 @@ export const useClientAttributesWithSubvalues = (teiId: string, program: InputPr
             const computedAttributes = await programTrackedEntityAttributes.reduce(async (promisedAcc, currentTEA) => {
                 const {
                     displayInList,
-                    trackedEntityAttribute: { id, optionSet, valueType, unique, displayFormName },
+                    trackedEntityAttribute: { id, optionSet, valueType, unique, displayFormName, access },
                 } = currentTEA;
+                if (access?.read === false) {
+                    return promisedAcc;
+                }
                 const foundAttribute = trackedEntityInstanceAttributes?.find(item => item.attribute === id);
                 let value;
                 if (foundAttribute) {

--- a/src/core_modules/capture-core/components/WidgetProfile/hooks/useClientAttributesWithSubvalues.js
+++ b/src/core_modules/capture-core/components/WidgetProfile/hooks/useClientAttributesWithSubvalues.js
@@ -23,7 +23,6 @@ type InputProgramData = {
             unique: boolean,
             access?: ?{
                 read?: ?boolean,
-                write?: ?boolean,
             }
         },
         displayInList: boolean,


### PR DESCRIPTION
**Task:** https://app.clickup.com/t/869cjkean

**Description:**

Fetch `access[read]` for trackedEntityAttributes and use it to control visibility. Attributes without read access are hidden from both the profile display and the edit form. 

If no `access` field is returned by the API, it fallbacks to previous behavior.

**Examples:**

Before
<img width="461" height="614" alt="imagen" src="https://github.com/user-attachments/assets/86cb3000-c581-4d66-a629-34e78a125dbf" />
After
<img width="456" height="433" alt="imagen" src="https://github.com/user-attachments/assets/ff03511c-0599-433d-bb93-9cbe93cdc1db" />

Before
<img width="782" height="844" alt="imagen" src="https://github.com/user-attachments/assets/370ccbff-d0be-4444-9f00-c1110090a3d8" />
After
<img width="794" height="814" alt="imagen" src="https://github.com/user-attachments/assets/51eefa3f-9458-4111-9bb4-22900d8cb151" />



