### PR TITLE
[SP] [105.13.5] feat: download CSV as displayed in the list

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2026-03-17T09:58:03.655Z\n"
-"PO-Revision-Date: 2026-03-17T09:58:03.655Z\n"
+"POT-Creation-Date: 2026-04-21T13:37:17.246Z\n"
+"PO-Revision-Date: 2026-04-21T13:37:17.246Z\n"
 
 msgid "The application could not be loaded."
 msgstr "The application could not be loaded."
@@ -2150,14 +2150,29 @@ msgstr[1] "{{count}} selected"
 msgid "Deselect all"
 msgstr "Deselect all"
 
+msgid "Export was truncated (maximum {{limit}} rows)."
+msgstr "Export was truncated (maximum {{limit}} rows)."
+
+msgid "Failed to export CSV"
+msgstr "Failed to export CSV"
+
 msgid "Download as JSON"
 msgstr "Download as JSON"
 
 msgid "Download as CSV"
 msgstr "Download as CSV"
 
+msgid "Download current view as CSV"
+msgstr "Download current view as CSV"
+
 msgid "Download with current filters"
 msgstr "Download with current filters"
+
+msgid "Downloading ({{loaded}} of ~{{total}})"
+msgstr "Downloading ({{loaded}} of ~{{total}})"
+
+msgid "Downloading ({{loaded}})"
+msgstr "Downloading ({{loaded}})"
 
 msgid "Exact matches only"
 msgstr "Exact matches only"

--- a/src/core_modules/capture-core/components/WorkingLists/TrackerWorkingLists/ViewMenuSetup/TrackerWorkingListsViewMenuSetup.component.tsx
+++ b/src/core_modules/capture-core/components/WorkingLists/TrackerWorkingLists/ViewMenuSetup/TrackerWorkingListsViewMenuSetup.component.tsx
@@ -1,16 +1,26 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { v4 as uuid } from 'uuid';
 import { useSelector } from 'react-redux';
-import { useDataEngine } from '@dhis2/app-runtime';
+import { useConfig, useDataEngine } from '@dhis2/app-runtime';
+import { buildUrl } from 'capture-core-utils';
 import { makeQuerySingleResource } from 'capture-core/utils/api';
 import i18n from '@dhis2/d2-i18n';
 import { TrackerWorkingListsTopBarActionsSetup } from '../ActionsSetup';
 import type { CustomMenuContents } from '../../WorkingListsBase';
 import type { Props } from './trackerWorkingListsViewMenuSetup.types';
-import { DownloadDialog, useSelectedRowsController } from '../../WorkingListsCommon';
+import { DownloadDialog, useColumns, useSelectedRowsController } from '../../WorkingListsCommon';
+import { useDefaultColumnConfig } from '../Setup/hooks';
 import { computeDownloadRequest } from './downloadRequest';
+import { fetchAllTeisForExport } from './fetchAllTeisForExport';
+import { buildColumnsMetaForDataFetching } from './buildColumnsMetaForDataFetching';
 import { convertToClientConfig } from '../helpers/TEIFilters';
 import { TrackedEntityBulkActions } from '../TrackedEntityBulkActions';
+import type { TrackerWorkingListsColumnConfig, TrackerWorkingListsColumnConfigs } from '../types';
+
+type WorkingListsState = {
+    workingLists: { [storeId: string]: { currentRequest?: { url: string; queryParams?: any } } };
+    workingListsColumnsOrder: { [storeId: string]: Array<{ id: string; visible: boolean }> | undefined };
+};
 
 export const TrackerWorkingListsViewMenuSetup = ({
     onLoadView,
@@ -35,9 +45,30 @@ export const TrackerWorkingListsViewMenuSetup = ({
         removeRowsFromSelection,
     } = useSelectedRowsController({ recordIds: recordsOrder });
     const downloadRequest = useSelector(
-        ({ workingLists }: any) => workingLists[storeId] && workingLists[storeId].currentRequest,
+        (state: WorkingListsState) => state.workingLists[storeId]?.currentRequest,
+    );
+    const customColumnOrder = useSelector(
+        (state: WorkingListsState) => state.workingListsColumnsOrder?.[storeId],
+    );
+    const defaultColumns = useDefaultColumnConfig(program, orgUnitId, programStageId);
+    const computedColumns = useColumns<TrackerWorkingListsColumnConfigs>(customColumnOrder, defaultColumns);
+    const exportColumns = useMemo(
+        () =>
+            (computedColumns || []).map((column: TrackerWorkingListsColumnConfig) => ({
+                id: column.id,
+                header: column.header,
+                visible: column.visible,
+                type: column.type,
+                options: column.options ?? null,
+            })),
+        [computedColumns],
+    );
+    const columnsMetaForDataFetching = useMemo(
+        () => buildColumnsMetaForDataFetching(defaultColumns),
+        [defaultColumns],
     );
     const dataEngine = useDataEngine();
+    const { baseUrl, apiVersion } = useConfig();
     const [downloadDialogOpen, setDownloadDialogOpenStatus] = useState(false);
     const customListViewMenuContents: CustomMenuContents = useMemo(() => {
         if (programStageId || !orgUnitId) {
@@ -59,11 +90,11 @@ export const TrackerWorkingListsViewMenuSetup = ({
 
     const injectDownloadRequestToLoadView = useCallback(
         async (selectedTemplate: any, context: any, meta: any) => {
-            const { columnsMetaForDataFetching, filtersOnlyMetaForDataFetching } = meta;
+            const { columnsMetaForDataFetching: injectedMeta, filtersOnlyMetaForDataFetching } = meta;
             const querySingleResource = makeQuerySingleResource(dataEngine.query.bind(dataEngine));
             const clientConfig = await convertToClientConfig(
                 selectedTemplate,
-                columnsMetaForDataFetching,
+                injectedMeta,
                 querySingleResource,
             );
             const currentRequest = computeDownloadRequest({
@@ -73,7 +104,7 @@ export const TrackerWorkingListsViewMenuSetup = ({
                     orgUnitId: context.orgUnitId,
                     storeId,
                 },
-                meta: { columnsMetaForDataFetching },
+                meta: { columnsMetaForDataFetching: injectedMeta },
                 filtersOnlyMetaForDataFetching,
             });
 
@@ -84,7 +115,7 @@ export const TrackerWorkingListsViewMenuSetup = ({
 
     const injectDownloadRequestToUpdateList = useCallback(
         (queryArgs: any, meta: any) => {
-            const { lastTransaction, columnsMetaForDataFetching, filtersOnlyMetaForDataFetching } = meta;
+            const { lastTransaction, columnsMetaForDataFetching: injectedMeta, filtersOnlyMetaForDataFetching } = meta;
             const currentRequest = computeDownloadRequest({
                 clientConfig: queryArgs,
                 context: {
@@ -92,7 +123,7 @@ export const TrackerWorkingListsViewMenuSetup = ({
                     orgUnitId: queryArgs.orgUnitId,
                     storeId,
                 },
-                meta: { columnsMetaForDataFetching },
+                meta: { columnsMetaForDataFetching: injectedMeta },
                 filtersOnlyMetaForDataFetching,
             });
             return onUpdateList(queryArgs, { ...meta, currentRequest }, lastTransaction);
@@ -100,11 +131,35 @@ export const TrackerWorkingListsViewMenuSetup = ({
         [onUpdateList, storeId],
     );
 
+    const handleFetchAllForView = useCallback(
+        async ({ onProgress, isCancelled }: {
+            onProgress: (loaded: number, total?: number) => void;
+            isCancelled: () => boolean;
+        }) => {
+            if (!downloadRequest) {
+                return { records: [] };
+            }
+            const querySingleResource = makeQuerySingleResource(dataEngine.query.bind(dataEngine));
+            const absoluteApiPath = buildUrl(baseUrl, `api/${apiVersion}`);
+            return fetchAllTeisForExport({
+                querySingleResource,
+                absoluteApiPath,
+                baseQueryParams: downloadRequest.queryParams || {},
+                programId: program.id,
+                columnsMetaForDataFetching,
+                onProgress,
+                isCancelled,
+            });
+        },
+        [dataEngine, downloadRequest, program.id, baseUrl, apiVersion, columnsMetaForDataFetching],
+    );
 
     const handleCustomUpdateTrigger = useCallback((disableClearSelection?: boolean) => {
         const id = uuid();
         setCustomUpdateTrigger(id);
-        !disableClearSelection && clearSelection();
+        if (!disableClearSelection) {
+            clearSelection();
+        }
     }, [clearSelection]);
 
     const TrackedEntityBulkActionsComponent = useMemo(() => (
@@ -156,6 +211,9 @@ export const TrackerWorkingListsViewMenuSetup = ({
                 open={downloadDialogOpen}
                 onClose={handleCloseDialog}
                 request={downloadRequest}
+                columns={exportColumns}
+                onFetchAllForView={handleFetchAllForView}
+                fileNameBase={`${program.shortName || program.name || 'tracked-entities'}-view`}
             />
         </>
     );

--- a/src/core_modules/capture-core/components/WorkingLists/TrackerWorkingLists/ViewMenuSetup/buildColumnsMetaForDataFetching.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/TrackerWorkingLists/ViewMenuSetup/buildColumnsMetaForDataFetching.ts
@@ -1,0 +1,34 @@
+import type {
+    TeiColumnsMetaForDataFetching,
+    TrackerWorkingListsColumnConfig,
+    TrackerWorkingListsColumnConfigs,
+} from '../types';
+
+export const buildColumnsMetaForDataFetching = (
+    defaultColumns: TrackerWorkingListsColumnConfigs,
+): TeiColumnsMetaForDataFetching =>
+    new Map(
+        defaultColumns.map((defaultColumn: TrackerWorkingListsColumnConfig) => {
+            const { id, type, visible, apiViewName, searchOperator, minCharactersToSearch } = defaultColumn;
+            const mainProperty = 'mainProperty' in defaultColumn &&
+                defaultColumn.mainProperty &&
+                typeof (defaultColumn as any).mainProperty === 'boolean'
+                ? defaultColumn.mainProperty
+                : undefined;
+            const additionalColumn = defaultColumn.additionalColumn ? defaultColumn.additionalColumn : undefined;
+
+            return [
+                id,
+                {
+                    id,
+                    type,
+                    visible,
+                    mainProperty,
+                    additionalColumn,
+                    apiViewName,
+                    searchOperator,
+                    minCharactersToSearch,
+                },
+            ];
+        }),
+    );

--- a/src/core_modules/capture-core/components/WorkingLists/TrackerWorkingLists/ViewMenuSetup/fetchAllTeisForExport.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/TrackerWorkingLists/ViewMenuSetup/fetchAllTeisForExport.ts
@@ -1,0 +1,125 @@
+import { handleAPIResponse, REQUESTED_ENTITIES } from 'capture-core/utils/api';
+import type { QuerySingleResource } from 'capture-core/utils/api';
+import { convertToClientTeis } from '../epics/teiViewEpics/helpers/getTeiListData/convertToClientTeis';
+import { getSubvalues } from '../epics/teiViewEpics/helpers/getListDataCommon';
+import { EXPORT_PAGE_SIZE, HARD_ROW_CAP } from '../../WorkingListsCommon/DownloadDialog/csvExport/constants';
+import type { TeiColumnsMetaForDataFetching } from '../types';
+
+const MAX_RETRIES_PER_PAGE = 2;
+const RETRY_BACKOFF_MS = 800;
+
+type ProgressCallback = (loaded: number, total?: number) => void;
+type FetchAllArgs = {
+    querySingleResource: QuerySingleResource;
+    absoluteApiPath: string;
+    baseQueryParams: { [key: string]: any };
+    programId: string;
+    columnsMetaForDataFetching: TeiColumnsMetaForDataFetching;
+    onProgress?: ProgressCallback;
+    isCancelled?: () => boolean;
+};
+
+export type FetchAllForExportResult = {
+    records: Array<{ id: string; record: { [k: string]: any } }>;
+    truncated?: boolean;
+    error?: string;
+};
+
+const sleep = (ms: number) => new Promise<void>((resolve) => { setTimeout(resolve, ms); });
+
+const fetchPageWithRetry = async (
+    querySingleResource: QuerySingleResource,
+    params: { [key: string]: any },
+) => {
+    let lastError: unknown;
+    for (let attempt = 0; attempt <= MAX_RETRIES_PER_PAGE; attempt += 1) {
+        try {
+            // eslint-disable-next-line no-await-in-loop
+            return await querySingleResource({ resource: 'tracker/trackedEntities', params });
+        } catch (error) {
+            lastError = error;
+            if (attempt < MAX_RETRIES_PER_PAGE) {
+                // eslint-disable-next-line no-await-in-loop
+                await sleep(RETRY_BACKOFF_MS * (attempt + 1));
+            }
+        }
+    }
+    throw lastError;
+};
+
+export const fetchAllTeisForExport = async ({
+    querySingleResource,
+    absoluteApiPath,
+    baseQueryParams,
+    programId,
+    columnsMetaForDataFetching,
+    onProgress,
+    isCancelled,
+}: FetchAllArgs): Promise<FetchAllForExportResult> => {
+    const { page: _ignoredPage, pageSize: _ignoredSize, ...rest } = baseQueryParams || {};
+    const columnsArray = [...columnsMetaForDataFetching.values()];
+    const collected: Array<{ id: string; record: { [k: string]: any } }> = [];
+    const addSubvalues = getSubvalues(querySingleResource, absoluteApiPath);
+
+    let page = 1;
+    let totalRows: number | undefined;
+    let truncated = false;
+    let errorMessage: string | undefined;
+
+    const emitProgress = () => {
+        if (!onProgress) return;
+        const total = totalRows != null ? Math.min(totalRows, HARD_ROW_CAP) : undefined;
+        onProgress(collected.length, total);
+    };
+
+    while (!(isCancelled && isCancelled())) {
+        const params: { [key: string]: any } = { ...rest, page, pageSize: EXPORT_PAGE_SIZE };
+        if (page === 1) {
+            params.totalPages = true;
+        }
+
+        let response: any;
+        try {
+            // eslint-disable-next-line no-await-in-loop
+            response = await fetchPageWithRetry(querySingleResource, params);
+        } catch (error: any) {
+            errorMessage = error?.message || 'Failed to fetch a page of tracked entities.';
+            truncated = true;
+            break;
+        }
+
+        const apiTeis = handleAPIResponse(REQUESTED_ENTITIES.trackedEntities, response);
+
+        if (page === 1 && response?.pager) {
+            if (typeof response.pager.total === 'number') {
+                totalRows = response.pager.total;
+            } else if (typeof response.pager.pageCount === 'number') {
+                totalRows = response.pager.pageCount * EXPORT_PAGE_SIZE;
+            }
+        }
+
+        const clientTeis = convertToClientTeis(apiTeis, columnsArray, programId);
+        let clientTeisWithSubvalues: typeof clientTeis = clientTeis;
+        try {
+            // eslint-disable-next-line no-await-in-loop
+            clientTeisWithSubvalues = await addSubvalues(clientTeis, columnsArray);
+        } catch (error: any) {
+            // Subvalue resolution is best-effort; fall back to the raw client TEIs.
+            errorMessage = errorMessage
+                || error?.message
+                || 'Failed to resolve file/image subvalues on one or more rows.';
+        }
+
+        collected.push(...clientTeisWithSubvalues);
+        emitProgress();
+
+        if (collected.length >= HARD_ROW_CAP) {
+            truncated = true;
+            break;
+        }
+        if (apiTeis.length < EXPORT_PAGE_SIZE) break;
+        page += 1;
+    }
+
+    return { records: collected, truncated, error: errorMessage };
+};

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/DownloadDialog/DownloadDialog.component.tsx
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/DownloadDialog/DownloadDialog.component.tsx
@@ -1,11 +1,19 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import i18n from '@dhis2/d2-i18n';
 import { withStyles, type WithStyles } from 'capture-core-utils/styles';
 import { featureAvailable, FEATURES } from 'capture-core-utils';
-import { Button, Modal, ModalTitle, ModalContent, ModalActions } from '@dhis2/ui';
+import { Button, CircularLoader, colors, Modal, ModalTitle, ModalContent, ModalActions } from '@dhis2/ui';
 import type { PlainProps } from './DownloadDialog.types';
+import { buildCsvRows } from './csvExport/buildCsv';
+import { downloadCsvRows } from './csvExport/downloadBlob';
+import { HARD_ROW_CAP } from './csvExport/constants';
 
-const getStyles: Readonly<any> = {
+const VIEW_EXPORT_HELP_TEXT = i18n.t(
+    // eslint-disable-next-line max-len
+    '"Download current view as CSV" exports the list with the same columns and filters shown on screen, across all pages.',
+);
+
+const getStyles = {
     downloadLink: {
         textDecoration: 'none',
         outline: 'none',
@@ -18,23 +26,102 @@ const getStyles: Readonly<any> = {
         display: 'flex',
         flexWrap: 'wrap',
     },
+    progress: {
+        display: 'flex',
+        alignItems: 'center',
+        gap: 8,
+        paddingTop: 8,
+    },
+    error: {
+        color: colors.red700,
+        paddingTop: 8,
+    },
+    note: {
+        paddingTop: 8,
+        fontSize: 12,
+        color: colors.grey700,
+    },
 };
 
 type Props = PlainProps & WithStyles<typeof getStyles>;
 
-const DownloadDialogPlain = ({ open, onClose, request, absoluteApiPath, classes }: Props) => {
-    const getUrlEncodedParamsString = (params: any) => {
-        const { filter, ...restParams } = params;
-        const searchParams = new URLSearchParams(restParams);
+const getUrlEncodedParamsString = (params: any) => {
+    const { filter, ...restParams } = params;
+    const searchParams = new URLSearchParams(restParams);
 
-        if (filter) {
-            filter.forEach((filterItem: string) => {
-                searchParams.append('filter', filterItem);
+    if (filter) {
+        filter.forEach((filterItem: string) => {
+            searchParams.append('filter', filterItem);
+        });
+    }
+
+    return searchParams.toString();
+};
+
+const DownloadDialogPlain = ({
+    open,
+    onClose,
+    request,
+    absoluteApiPath,
+    columns,
+    onFetchAllForView,
+    fileNameBase,
+    classes,
+}: Props) => {
+    const [exporting, setExporting] = useState(false);
+    const [progress, setProgress] = useState<{ loaded: number; total?: number }>({ loaded: 0 });
+    const [message, setMessage] = useState<string | null>(null);
+    const cancelledRef = useRef(false);
+
+    const viewExportReady = Boolean(
+        onFetchAllForView && columns && columns.some(c => c.visible) && request?.url,
+    );
+
+    const handleDownloadCurrentView = useCallback(async () => {
+        if (!onFetchAllForView || !columns) return;
+        setMessage(null);
+        setExporting(true);
+        setProgress({ loaded: 0 });
+        cancelledRef.current = false;
+        try {
+            const result = await onFetchAllForView({
+                onProgress: (loaded, total) => setProgress({ loaded, total }),
+                isCancelled: () => cancelledRef.current,
             });
+            if (cancelledRef.current) {
+                setExporting(false);
+                return;
+            }
+            const rows = buildCsvRows(result.records, columns);
+            const base = fileNameBase || 'tracked-entities';
+            downloadCsvRows(rows, `${base}.csv`);
+            const notices: Array<string> = [];
+            if (result.truncated) {
+                notices.push(
+                    i18n.t('Export was truncated (maximum {{limit}} rows).', { limit: HARD_ROW_CAP }),
+                );
+            }
+            if (result.error) {
+                notices.push(i18n.t('Some rows may be missing: {{reason}}', { reason: result.error }));
+            }
+            if (notices.length > 0) setMessage(notices.join(' '));
+        } catch (e: any) {
+            setMessage(e?.message || i18n.t('Failed to export CSV'));
+        } finally {
+            setExporting(false);
         }
+    }, [onFetchAllForView, columns, fileNameBase]);
 
-        return searchParams.toString();
-    };
+    const handleCancelExport = useCallback(() => {
+        cancelledRef.current = true;
+        setExporting(false);
+    }, []);
+
+    const handleCloseDialog = useCallback(() => {
+        if (exporting) return;
+        setMessage(null);
+        onClose();
+    }, [exporting, onClose]);
 
     const renderButtons = () => {
         if (!request?.url) return null;
@@ -56,7 +143,7 @@ const DownloadDialogPlain = ({ open, onClose, request, absoluteApiPath, classes 
                         href={`${url}.json?${searchParamsString}`}
                         className={classes.downloadLink}
                     >
-                        <Button>{i18n.t('Download as JSON')}</Button>
+                        <Button disabled={exporting}>{i18n.t('Download as JSON')}</Button>
                     </a>
                 </div>
                 <div className={classes.downloadLinkContainer}>
@@ -65,9 +152,20 @@ const DownloadDialogPlain = ({ open, onClose, request, absoluteApiPath, classes 
                         href={`${url}.csv?${searchParamsString}`}
                         className={classes.downloadLink}
                     >
-                        <Button>{i18n.t('Download as CSV')}</Button>
+                        <Button disabled={exporting}>{i18n.t('Download as CSV')}</Button>
                     </a>
                 </div>
+                {onFetchAllForView && (
+                    <div className={classes.downloadLinkContainer}>
+                        <Button
+                            onClick={handleDownloadCurrentView}
+                            disabled={exporting || !viewExportReady}
+                            dataTest="working-lists-download-current-view-csv"
+                        >
+                            {i18n.t('Download current view as CSV')}
+                        </Button>
+                    </div>
+                )}
             </div>
         );
     };
@@ -77,11 +175,31 @@ const DownloadDialogPlain = ({ open, onClose, request, absoluteApiPath, classes 
     }
 
     return (
-        <Modal hide={!open} onClose={onClose} position="middle" dataTest="working-lists-download-dialog">
+        <Modal hide={!open} onClose={handleCloseDialog} position="middle" dataTest="working-lists-download-dialog">
             <ModalTitle>{i18n.t('Download with current filters')}</ModalTitle>
-            <ModalContent>{renderButtons()}</ModalContent>
+            <ModalContent>
+                {renderButtons()}
+                {onFetchAllForView && <div className={classes.note}>{VIEW_EXPORT_HELP_TEXT}</div>}
+                {exporting && (
+                    <div className={classes.progress}>
+                        <CircularLoader small />
+                        <span>
+                            {progress.total
+                                ? i18n.t('Downloading ({{loaded}} of ~{{total}})', {
+                                    loaded: progress.loaded,
+                                    total: progress.total,
+                                })
+                                : i18n.t('Downloading ({{loaded}})', { loaded: progress.loaded })}
+                        </span>
+                        <Button small secondary onClick={handleCancelExport}>
+                            {i18n.t('Cancel')}
+                        </Button>
+                    </div>
+                )}
+                {message && <div className={classes.error}>{message}</div>}
+            </ModalContent>
             <ModalActions>
-                <Button onClick={onClose} color="primary">
+                <Button onClick={handleCloseDialog} color="primary" disabled={exporting}>
                     {i18n.t('Close')}
                 </Button>
             </ModalActions>

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/DownloadDialog/DownloadDialog.container.tsx
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/DownloadDialog/DownloadDialog.container.tsx
@@ -4,7 +4,14 @@ import { buildUrl } from 'capture-core-utils';
 import { DownloadDialogComponent } from './DownloadDialog.component';
 import type { Props } from './DownloadDialog.types';
 
-export const DownloadDialog = ({ request, open, onClose }: Props) => {
+export const DownloadDialog = ({
+    request,
+    open,
+    onClose,
+    columns,
+    onFetchAllForView,
+    fileNameBase,
+}: Props) => {
     const { baseUrl, apiVersion } = useConfig();
     const absoluteApiPath = buildUrl(baseUrl, `api/${apiVersion}`);
 
@@ -14,6 +21,9 @@ export const DownloadDialog = ({ request, open, onClose }: Props) => {
             absoluteApiPath={absoluteApiPath}
             open={open}
             onClose={onClose}
+            columns={columns}
+            onFetchAllForView={onFetchAllForView}
+            fileNameBase={fileNameBase}
         />
     );
 };

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/DownloadDialog/DownloadDialog.types.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/DownloadDialog/DownloadDialog.types.ts
@@ -1,7 +1,23 @@
+import type { CsvColumn } from './csvExport/buildCsv';
+
+export type ViewExportFetchResult = {
+    records: Array<{ id: string; record: { [key: string]: any } }>;
+    truncated?: boolean;
+    error?: string;
+};
+
+export type ViewExportFetcher = (args: {
+    onProgress: (loaded: number, total?: number) => void;
+    isCancelled: () => boolean;
+}) => Promise<ViewExportFetchResult>;
+
 export type Props = {
-    request: { url: string; queryParams?: any };
+    request?: { url: string; queryParams?: any };
     open: boolean;
     onClose: () => void;
+    columns?: Array<CsvColumn>;
+    onFetchAllForView?: ViewExportFetcher;
+    fileNameBase?: string;
 };
 
 export type PlainProps = {
@@ -9,4 +25,7 @@ export type PlainProps = {
     onClose: () => void;
     absoluteApiPath: string;
     request?: { url: string; queryParams?: any };
+    columns?: Array<CsvColumn>;
+    onFetchAllForView?: ViewExportFetcher;
+    fileNameBase?: string;
 };

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/DownloadDialog/csvExport/buildCsv.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/DownloadDialog/csvExport/buildCsv.ts
@@ -1,0 +1,151 @@
+import i18n from '@dhis2/d2-i18n';
+import { dataElementTypes } from '../../../../../metaData';
+
+export type CsvColumnOption = { text: string; value: any };
+
+export type CsvColumn = {
+    id: string;
+    header: string;
+    visible: boolean;
+    type?: string;
+    options?: Array<CsvColumnOption> | null;
+};
+
+export type CsvRecord = { [id: string]: any };
+
+const escapeCell = (raw: string) => `"${raw.replace(/"/g, '""')}"`;
+
+const stringifyCoordinate = (value: any): string => {
+    if (Array.isArray(value) && value.length >= 2) {
+        const [lng, lat] = value;
+        return `${lat}, ${lng}`;
+    }
+    if (value && typeof value === 'object') {
+        if (value.latitude != null && value.longitude != null) {
+            return `${value.latitude}, ${value.longitude}`;
+        }
+        if (value.coordinates && Array.isArray(value.coordinates)) {
+            return stringifyCoordinate(value.coordinates);
+        }
+    }
+    return String(value);
+};
+
+const extractFileName = (value: any): string => {
+    if (value == null) return '';
+    if (typeof value === 'object') {
+        if (value.name) return String(value.name);
+        if (value.url) return String(value.url);
+        if (value.value !== undefined) return String(value.value);
+    }
+    return String(value);
+};
+
+const extractOrgUnit = (value: any): string => {
+    if (value == null) return '';
+    if (typeof value === 'object') {
+        if (value.name) return String(value.name);
+        if (value.displayName) return String(value.displayName);
+        if (value.id) return String(value.id);
+    }
+    return String(value);
+};
+
+const formatPrimitive = (value: any, type?: string): string => {
+    if (value == null) return '';
+    if (typeof value === 'boolean') return value ? i18n.t('Yes') : i18n.t('No');
+
+    switch (type) {
+    case dataElementTypes.BOOLEAN:
+        return value ? i18n.t('Yes') : i18n.t('No');
+    case dataElementTypes.TRUE_ONLY:
+        return i18n.t('Yes');
+    case dataElementTypes.FILE_RESOURCE:
+        return extractFileName(value);
+    case dataElementTypes.IMAGE:
+        if (value && typeof value === 'object') {
+            return String(value.url || value.value || value.name || '');
+        }
+        return String(value);
+    case dataElementTypes.ORGANISATION_UNIT:
+        return extractOrgUnit(value);
+    case dataElementTypes.COORDINATE:
+    case dataElementTypes.POLYGON:
+        return stringifyCoordinate(value);
+    case dataElementTypes.ASSIGNEE:
+        if (value && typeof value === 'object') {
+            const name = value.name || value.displayName || '';
+            const username = value.username ? ` (${value.username})` : '';
+            return `${name}${username}`.trim();
+        }
+        return String(value);
+    case dataElementTypes.STATUS:
+        if (value && typeof value === 'object' && value.text) {
+            return String(value.text);
+        }
+        return String(value);
+    default:
+        break;
+    }
+
+    if (Array.isArray(value)) return value.map(v => formatPrimitive(v, type)).join('; ');
+    if (typeof value === 'object') {
+        if (value.name) return String(value.name);
+        if (value.displayName) return String(value.displayName);
+        if (value.url) return String(value.url);
+        if (value.value !== undefined) return String(value.value);
+        if (value.id) return String(value.id);
+        return JSON.stringify(value);
+    }
+    return String(value);
+};
+
+const lookupOption = (rawValue: any, options: Array<CsvColumnOption>): string => {
+    const match = options.find(o => o.value === rawValue || String(o.value) === String(rawValue));
+    return match ? String(match.text) : String(rawValue);
+};
+
+const formatWithOptions = (
+    value: any,
+    options: Array<CsvColumnOption>,
+    type?: string,
+): string => {
+    if (value == null) return '';
+    if (Array.isArray(value)) {
+        return value.map(v => lookupOption(v, options)).join('; ');
+    }
+    if (type === dataElementTypes.MULTI_TEXT && typeof value === 'string') {
+        return value
+            .split(',')
+            .map(part => part.trim())
+            .filter(part => part.length > 0)
+            .map(part => lookupOption(part, options))
+            .join('; ');
+    }
+    return lookupOption(value, options);
+};
+
+const formatCell = (value: any, column: CsvColumn): string => {
+    if (column.options && column.options.length > 0) {
+        return formatWithOptions(value, column.options, column.type);
+    }
+    return formatPrimitive(value, column.type);
+};
+
+export const buildCsvRows = (
+    records: Array<{ id: string; record: CsvRecord }>,
+    columns: Array<CsvColumn>,
+): Array<string> => {
+    const visibleColumns = columns.filter(c => c.visible);
+    const rows: Array<string> = [];
+    rows.push(visibleColumns.map(c => escapeCell(c.header || c.id)).join(','));
+    for (const { record } of records) {
+        rows.push(visibleColumns.map(column => escapeCell(formatCell(record[column.id], column))).join(','));
+    }
+    return rows;
+};
+
+export const buildCsv = (
+    records: Array<{ id: string; record: CsvRecord }>,
+    columns: Array<CsvColumn>,
+): string => buildCsvRows(records, columns).join('\r\n');

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/DownloadDialog/csvExport/constants.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/DownloadDialog/csvExport/constants.ts
@@ -1,0 +1,2 @@
+export const EXPORT_PAGE_SIZE = 500;
+export const HARD_ROW_CAP = 20000;

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/DownloadDialog/csvExport/downloadBlob.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/DownloadDialog/csvExport/downloadBlob.ts
@@ -1,0 +1,22 @@
+const UTF8_BOM = '﻿';
+const ROW_SEPARATOR = '\r\n';
+
+const sanitizeFileName = (name: string): string =>
+    name.replace(/[^\w.\-]+/g, '_').replace(/_+/g, '_').replace(/^_+|_+$/g, '') || 'download';
+
+export const downloadCsvRows = (rows: Array<string>, fileName: string) => {
+    const parts: Array<string> = [UTF8_BOM];
+    rows.forEach((row, index) => {
+        parts.push(row);
+        if (index < rows.length - 1) parts.push(ROW_SEPARATOR);
+    });
+    const blob = new Blob(parts, { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = sanitizeFileName(fileName);
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(url);
+};


### PR DESCRIPTION
**Task:** https://app.clickup.com/t/869czvkrw

## Summary

Adds a new **"Download current view as CSV"** option to the Tracker working-lists Download dialog. Unlike the existing server-side CSV (which returns one row per tracked-entity-attribute in a long/pivoted format), the new export produces a CSV that mirrors the grid exactly — same visible columns, same ordering, same filters, across all pages — so users can open the file in Excel and see what they see on screen.

## Motivation

The current "Download as CSV" hits `tracker/trackedEntities.csv` and relies on the DHIS2 API's default CSV shape, which is unusable for users who expect one row per TEI matching the list view. Adding a proper wide-format export closes a long-standing usability gap without breaking the existing buttons.

## What's new

- **Third button** `Download current view as CSV` in the existing `DownloadDialog`. The original `Download as JSON` and `Download as CSV` buttons are untouched.
- **Client-side CSV generation** that mirrors the grid:
  - Reuses the list-view data pipeline (`convertToClientTeis` + `getSubvalues`) so values are formatted the same way the grid formats them (dates, option sets, file/image subvalues, etc.).
  - Option-set codes are translated to their display text (e.g. `OWNS_HOME` → `Owns a home`).
  - Type-aware formatting for `FILE_RESOURCE`, `IMAGE`, `COORDINATE`, `POLYGON`, `ORGANISATION_UNIT`, `ASSIGNEE`, `STATUS`, `BOOLEAN`, `TRUE_ONLY`, `MULTI_TEXT`.
- **Paginated fetch** over `tracker/trackedEntities`:
  - Page size 500, hard cap 20 000 rows.
  - Uses `pager.total` (fallback to `pageCount × pageSize`).
  - Per-page retry (2 attempts, 800 ms backoff) on transient failures.
  - Best-effort subvalue resolution — a subvalue failure no longer aborts the export; the row is emitted without that subvalue and a warning is shown.
  - Partial results are always returned with `truncated: true` and an `error` message when something goes wrong.
- **UX**:
  - Progress indicator (`X of ~Y`) with a Cancel button.
  - Truncation / partial-error notices shown after the download completes.
  - Close button disabled while exporting.
  - Button disabled until `columns` + `request` are ready (no silent empty exports).
- **Filename sanitised** (`[^\w.\-]` → `_`), derived from the program short name.
- **Excel-friendly**: UTF-8 BOM, CRLF line endings, RFC 4180 quoting.
- **Memory**: CSV is streamed into a `Blob` from an array of row strings, not one huge concatenated string.

## Files

**New**
- `WorkingListsCommon/DownloadDialog/csvExport/buildCsv.ts` — type-aware CSV builder (options, dates, files, coords, etc.).
- `WorkingListsCommon/DownloadDialog/csvExport/downloadBlob.ts` — Blob + anchor download, filename sanitiser.
- `WorkingListsCommon/DownloadDialog/csvExport/constants.ts` — `EXPORT_PAGE_SIZE`, `HARD_ROW_CAP`.
- `TrackerWorkingLists/ViewMenuSetup/fetchAllTeisForExport.ts` — paging + retry + partial-results fetcher.
- `TrackerWorkingLists/ViewMenuSetup/buildColumnsMetaForDataFetching.ts` — pure helper that constructs `TeiColumnsMetaForDataFetching` from default columns (extracted to avoid a stale ref in the view).

**Modified**
- `DownloadDialog.component.tsx`, `DownloadDialog.container.tsx`, `DownloadDialog.types.ts` — new button + progress/cancel/error UI + new optional props (`columns`, `onFetchAllForView`, `fileNameBase`). `Props.request` made optional. `DownloadDialog` stays a drop-in — callers that don't pass the new props keep the old behaviour.
- `TrackerWorkingListsViewMenuSetup.component.tsx` — reads `customColumnOrder` from Redux, re-builds `columns` and `columnsMetaForDataFetching` with `useDefaultColumnConfig` + `useColumns` (always fresh, no refs), and wires `onFetchAllForView`.
- `i18n/en.pot` — new strings (`Download current view as CSV`, progress, cancel, truncation, partial-error notices).

## Design choices / trade-offs

- **No new Redux state** — columns and request are derived live each render, so filter/sort/column changes are always reflected in the export.
- **Module boundary respected** — constants live in `WorkingListsCommon`; the tracker-specific fetcher imports from there, not the other way round.
- **Existing server-side CSV/JSON kept** — some integrations depend on the long format, and this is the safest way to ship.
- **Best-effort subvalue handling** — a broken `fileResources` lookup shouldn't kill a 10 000-row export.
- **50 k → 20 k cap** — reduced after review for memory safety on weaker devices. Tunable via the new `constants.ts`.

## Known limitations (deferred)

- Cancel stops the paging loop but doesn't abort the in-flight request (`querySingleResource` has no abort path here). UI unblocks immediately regardless.
- Subvalues are resolved per page; an end-of-run batch dedupe would save round trips on large exports with many file/image columns.
- OrgUnit cells export whatever value is in the client record (name if resolved, id otherwise) — good enough for the common cases.

## Test plan

- [ ] Manual: load Tracker list, change filters/sort/column order, open the dialog — confirm the new button is enabled and matches the grid.
- [ ] Verify export for programs with: text, date, number, option-set (single + multi-text), boolean, file/image, org-unit, status, and assignee columns.
- [ ] Multi-page export (> 1 000 TEIs) with a cancel partway.
- [ ] Very large dataset (> 20 000 TEIs) → truncation notice appears.
- [ ] Simulated network failure mid-export → partial CSV + error banner.
- [ ] Existing "Download as JSON" and "Download as CSV" buttons still behave the same.
- [ ] `yarn tsc:check` and `yarn linter:check` pass.