### PR TITLE
[SP] [105.13.5] feat: show total results and page count in pagination

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2026-03-17T09:58:03.655Z\n"
-"PO-Revision-Date: 2026-03-17T09:58:03.655Z\n"
+"POT-Creation-Date: 2026-04-21T15:20:41.203Z\n"
+"PO-Revision-Date: 2026-04-21T15:20:41.203Z\n"
 
 msgid "The application could not be loaded."
 msgstr "The application could not be loaded."
@@ -2305,8 +2305,16 @@ msgstr "To date"
 msgid "To time"
 msgstr "To time"
 
+msgid "Page {{currentPage}} of {{pageCount}}"
+msgstr "Page {{currentPage}} of {{pageCount}}"
+
 msgid "Page {{currentPage}}"
 msgstr "Page {{currentPage}}"
+
+msgid "{{count}} result"
+msgid_plural "{{count}} result"
+msgstr[0] "{{count}} result"
+msgstr[1] "{{count}} results"
 
 msgid "Area on map saved"
 msgstr "Area on map saved"

--- a/src/core_modules/capture-core/components/ListView/ContextBuilder/ListViewContextBuilder.component.tsx
+++ b/src/core_modules/capture-core/components/ListView/ContextBuilder/ListViewContextBuilder.component.tsx
@@ -18,6 +18,8 @@ export const ListViewContextBuilder = ({
     onChangeRowsPerPage,
     rowsPerPage,
     currentPage,
+    total,
+    pageCount,
     dataSource,
     ...passOnProps
 }: Props) => {
@@ -27,12 +29,16 @@ export const ListViewContextBuilder = ({
         rowsPerPage,
         currentPage,
         rowCountPage: dataSource.length,
+        total,
+        pageCount,
     }), [
         onChangePage,
         onChangeRowsPerPage,
         rowsPerPage,
         currentPage,
         dataSource.length,
+        total,
+        pageCount,
     ]);
 
     return (

--- a/src/core_modules/capture-core/components/ListView/ContextBuilder/listViewContextBuilder.types.ts
+++ b/src/core_modules/capture-core/components/ListView/ContextBuilder/listViewContextBuilder.types.ts
@@ -1,6 +1,6 @@
-import type { FiltersData, ListViewPassOnProps, DataSource, ChangePage, ChangeRowsPerPage } from '../types';
+import type { FiltersData, ListViewPassOnProps, DataSource, ChangePage, ChangeRowsPerPage, PagingTotals } from '../types';
 
-type ComponentProps = {
+type ComponentProps = PagingTotals & {
     filters: FiltersData;
     onChangePage: ChangePage;
     onChangeRowsPerPage: ChangeRowsPerPage;

--- a/src/core_modules/capture-core/components/ListView/Pagination/ListPaginationMain.component.tsx
+++ b/src/core_modules/capture-core/components/ListView/Pagination/ListPaginationMain.component.tsx
@@ -5,9 +5,21 @@ import {
 } from 'capture-ui';
 import { withNavigation } from '../../Pagination/withDefaultNavigation';
 import { withRowsPerPageSelector } from '../../Pagination/withRowsPerPageSelector';
+import type { PagingTotals } from '../types';
 import type { Props } from './listPaginationMain.types';
 
-const PaginationWrapped = withRowsPerPageSelector()(withNavigation()(Pagination)) as any;
+type PaginationWrappedProps = PagingTotals & {
+    currentPage: number;
+    rowsPerPage: number;
+    rowsCountSelectorLabel?: string;
+    nextPageButtonDisabled: boolean;
+    onChangePage: (pageNumber: number) => void;
+    onChangeRowsPerPage: (rowsPerPage: number) => void;
+    disabled?: boolean;
+};
+
+const PaginationWrapped: React.ComponentType<PaginationWrappedProps> =
+    withRowsPerPageSelector()(withNavigation()(Pagination)) as any;
 
 export const ListPaginationMain = ({ rowCountPage, rowsPerPage, ...passOnProps }: Props) => (
     <PaginationWrapped

--- a/src/core_modules/capture-core/components/ListView/Pagination/listPaginationMain.types.ts
+++ b/src/core_modules/capture-core/components/ListView/Pagination/listPaginationMain.types.ts
@@ -1,6 +1,9 @@
-export type Props = {
+import type { PagingTotals } from '../types';
+
+export type Props = PagingTotals & {
     rowCountPage: number;
     rowsPerPage: number;
+    currentPage: number;
     onChangePage: (pageNumber: number) => void;
     onChangeRowsPerPage: (rowsPerPage: number) => void;
 };

--- a/src/core_modules/capture-core/components/ListView/index.ts
+++ b/src/core_modules/capture-core/components/ListView/index.ts
@@ -23,6 +23,7 @@ export type {
     ResetColumnOrder,
     SelectRow,
     Sort,
+    PagingTotals,
 } from './types';
 
 export { dateFilterTypes, assigneeFilterModes } from '../FiltersForTypes';

--- a/src/core_modules/capture-core/components/ListView/types/listView.types.ts
+++ b/src/core_modules/capture-core/components/ListView/types/listView.types.ts
@@ -18,6 +18,11 @@ export type Column = {
 
 export type Columns = Array<Column>;
 
+export type PagingTotals = {
+    total?: number | null;
+    pageCount?: number | null;
+};
+
 export type FilterOnly = {
     id: string;
     type: typeof dataElementTypes[keyof typeof dataElementTypes];
@@ -70,7 +75,7 @@ export type CustomTopBarActions = Array<{key: string, actionContents: ReactNode}
 
 export type FiltersData = { [id: string]: FilterData };
 
-export type PaginationContextData = {
+export type PaginationContextData = PagingTotals & {
     onChangePage: (pageNumber: number) => void;
     onChangeRowsPerPage: (rowsPerPage: number) => void;
     rowsPerPage: number;
@@ -94,7 +99,7 @@ export type SetColumnOrder = (columns: Columns) => void;
 export type ResetColumnOrder = () => void;
 export type SelectRow = (rowData: DataSourceItem) => void;
 export type Sort = (id: string, direction: string) => void;
-export type InterfaceProps = {
+export type InterfaceProps = PagingTotals & {
     columns?: Columns;
     filtersOnly?: FiltersOnly;
     additionalFilters?: AdditionalFilters;

--- a/src/core_modules/capture-core/components/WorkingLists/EventWorkingLists/epics/getEventListData.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/EventWorkingLists/epics/getEventListData.ts
@@ -160,6 +160,7 @@ export const createApiQueryArgs = (queryArgs: any, mainColumns: any, categoryCom
         ...getApiFilterQueryArgument(queryArgs.filters, mainColumns),
         ...getMainApiFilterQueryArguments(queryArgs.filters, mainColumns),
         ...getApiCategoriesQueryArgument(queryArgs.categories, categoryCombinationId),
+        totalPages: true,
     };
 
     apiQueryArgs.order?.includes('default') && delete apiQueryArgs.order;

--- a/src/core_modules/capture-core/components/WorkingLists/TrackerWorkingLists/epics/teiViewEpics/helpers/getEventListData/getEventListData.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/TrackerWorkingLists/epics/teiViewEpics/helpers/getEventListData/getEventListData.ts
@@ -85,8 +85,8 @@ export const getEventListData = async (
     const pagingData = {
         rowsPerPage: queryParamsEvents.pageSize,
         currentPage: queryParamsEvents.page,
-        total: apiEventsResponse?.total ?? null,
-        pageCount: apiEventsResponse?.pageCount ?? null,
+        total: apiEventsResponse?.total ?? apiEventsResponse?.pager?.total ?? null,
+        pageCount: apiEventsResponse?.pageCount ?? apiEventsResponse?.pager?.pageCount ?? null,
     };
 
     if (apiEvents.length === 0) {

--- a/src/core_modules/capture-core/components/WorkingLists/TrackerWorkingLists/epics/teiViewEpics/helpers/getEventListData/getEventListData.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/TrackerWorkingLists/epics/teiViewEpics/helpers/getEventListData/getEventListData.ts
@@ -46,6 +46,7 @@ const createApiEventQueryArgs = (
         program,
         programStage,
         fields: '*',
+        totalPages: true,
     };
 
     return getScheduledDateQueryArgs(queryArgs);
@@ -81,9 +82,17 @@ export const getEventListData = async (
     });
     const apiEvents = handleAPIResponse(REQUESTED_ENTITIES.events, apiEventsResponse);
 
+    const pagingData = {
+        rowsPerPage: queryParamsEvents.pageSize,
+        currentPage: queryParamsEvents.page,
+        total: apiEventsResponse?.total ?? null,
+        pageCount: apiEventsResponse?.pageCount ?? null,
+    };
+
     if (apiEvents.length === 0) {
         return {
             recordContainers: [],
+            pagingData,
             request: {
                 url: urlEvents,
                 queryParams: queryParamsEvents,
@@ -116,6 +125,7 @@ export const getEventListData = async (
     );
     return {
         recordContainers: clientWithSubvalues,
+        pagingData,
         request: {
             url: urlEvents,
             queryParams: queryParamsEvents,

--- a/src/core_modules/capture-core/components/WorkingLists/TrackerWorkingLists/epics/teiViewEpics/helpers/getTeiListData/getTeiListData.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/TrackerWorkingLists/epics/teiViewEpics/helpers/getTeiListData/getTeiListData.ts
@@ -41,6 +41,7 @@ filtersOnlyMetaForDataFetching: TeiFiltersOnlyMetaForDataFetching,
         [orgUnitModeQueryParam]: orgUnitId ? 'SELECTED' : 'ACCESSIBLE',
         program,
         fields: ':all,!relationships,programOwners[orgUnit,program]',
+        totalPages: true,
     };
 };
 
@@ -71,6 +72,12 @@ export const getTeiListData = async (
 
     return {
         recordContainers: clientTeisWithSubvalues,
+        pagingData: {
+            rowsPerPage: queryParams.pageSize,
+            currentPage: queryParams.page,
+            total: apiResponse?.total ?? null,
+            pageCount: apiResponse?.pageCount ?? null,
+        },
         request: {
             url,
             queryParams,

--- a/src/core_modules/capture-core/components/WorkingLists/TrackerWorkingLists/epics/teiViewEpics/helpers/getTeiListData/getTeiListData.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/TrackerWorkingLists/epics/teiViewEpics/helpers/getTeiListData/getTeiListData.ts
@@ -75,8 +75,8 @@ export const getTeiListData = async (
         pagingData: {
             rowsPerPage: queryParams.pageSize,
             currentPage: queryParams.page,
-            total: apiResponse?.total ?? null,
-            pageCount: apiResponse?.pageCount ?? null,
+            total: apiResponse?.total ?? apiResponse?.pager?.total ?? null,
+            pageCount: apiResponse?.pageCount ?? apiResponse?.pager?.pageCount ?? null,
         },
         request: {
             url,

--- a/src/core_modules/capture-core/components/WorkingLists/TrackerWorkingLists/epics/teiViewEpics/helpers/initTrackerWorkingListsView.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/TrackerWorkingLists/epics/teiViewEpics/helpers/initTrackerWorkingListsView.ts
@@ -50,13 +50,10 @@ export const initTrackerWorkingListsViewAsync = async ({
         : getTeiListData(rawQueryArgs, params);
 
     return promiseToGetRecordsList
-        .then(({ recordContainers, request }) =>
+        .then(({ recordContainers, pagingData, request }) =>
             initListViewSuccess(storeId, {
                 recordContainers,
-                pagingData: {
-                    rowsPerPage,
-                    currentPage,
-                },
+                pagingData,
                 request,
                 config: {
                     sortById,

--- a/src/core_modules/capture-core/components/WorkingLists/TrackerWorkingLists/epics/teiViewEpics/helpers/updateTrackerWorkingListsRecords.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/TrackerWorkingLists/epics/teiViewEpics/helpers/updateTrackerWorkingListsRecords.ts
@@ -38,8 +38,9 @@ export const updateTrackerWorkingListsRecords = ({
         : getTeiListData(rawQueryArgs, params);
 
     return promiseToUpdateRecordsList
-        .then(({ recordContainers, request }) => updateListSuccess(storeId, {
+        .then(({ recordContainers, pagingData, request }) => updateListSuccess(storeId, {
             recordContainers,
+            pagingData,
             request,
         })).catch((error) => {
             log.error(errorCreator('An error occurred when updating the working list records')({ error }));

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsBase/ContextBuilder/ContextProviders/WorkingListsListViewUpdaterContextProvider.component.tsx
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsBase/ContextBuilder/ContextProviders/WorkingListsListViewUpdaterContextProvider.component.tsx
@@ -7,6 +7,8 @@ import type { Props } from './workingListsListViewUpdaterContextProvider.types';
 export const WorkingListsListViewUpdaterContextProvider = ({
     rowsPerPage,
     currentPage,
+    total,
+    pageCount,
     onCancelUpdateList,
     customUpdateTrigger,
     forceUpdateOnMount,
@@ -17,6 +19,8 @@ export const WorkingListsListViewUpdaterContextProvider = ({
     const listViewUpdaterContextData = useMemo(() => ({
         rowsPerPage,
         currentPage,
+        total,
+        pageCount,
         onCancelUpdateList,
         customUpdateTrigger,
         forceUpdateOnMount,
@@ -25,6 +29,8 @@ export const WorkingListsListViewUpdaterContextProvider = ({
     }), [
         rowsPerPage,
         currentPage,
+        total,
+        pageCount,
         onCancelUpdateList,
         customUpdateTrigger,
         forceUpdateOnMount,

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsBase/ContextBuilder/ContextProviders/workingListsListViewUpdaterContextProvider.types.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsBase/ContextBuilder/ContextProviders/workingListsListViewUpdaterContextProvider.types.ts
@@ -1,9 +1,10 @@
 import type { ReactNode } from 'react';
+import type { PagingTotals } from '../../../../ListView';
 import type {
     CancelUpdateList,
 } from '../../workingListsBase.types';
 
-export type Props = Readonly<{
+export type Props = Readonly<PagingTotals & {
     rowsPerPage?: number,
     currentPage?: number,
     onCancelUpdateList?: CancelUpdateList,

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsBase/ContextBuilder/WorkingListsContextBuilder.component.tsx
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsBase/ContextBuilder/WorkingListsContextBuilder.component.tsx
@@ -52,6 +52,8 @@ export const WorkingListsContextBuilder = (props: Props) => {
         stickyFilters,
         rowsPerPage,
         currentPage,
+        total,
+        pageCount,
         currentViewHasTemplateChanges,
         viewPreloaded,
         customUpdateTrigger,
@@ -122,6 +124,8 @@ export const WorkingListsContextBuilder = (props: Props) => {
                     <WorkingListsListViewUpdaterContextProvider
                         rowsPerPage={rowsPerPage}
                         currentPage={currentPage}
+                        total={total}
+                        pageCount={pageCount}
                         onCancelUpdateList={onCancelUpdateList}
                         customUpdateTrigger={customUpdateTrigger}
                         forceUpdateOnMount={forceUpdateOnMount}

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsBase/ContextBuilder/workingListsContextBuilder.types.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsBase/ContextBuilder/workingListsContextBuilder.types.ts
@@ -7,6 +7,7 @@ import type {
     CustomTopBarActions,
     DataSource,
     FiltersData,
+    PagingTotals,
     RemoveFilter,
     SelectRestMenuItem,
     SelectRow,
@@ -33,7 +34,7 @@ import type {
     WorkingListTemplates,
 } from '../workingListsBase.types';
 
-type ExtractedProps = Readonly<{
+type ExtractedProps = Readonly<PagingTotals & {
     categories?: Categories,
     columns: ColumnConfigs,
     currentPage?: number,

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsBase/ListViewUpdater/ListViewUpdater.component.tsx
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsBase/ListViewUpdater/ListViewUpdater.component.tsx
@@ -62,6 +62,8 @@ export const ListViewUpdater = (props: Props) => {
     const {
         currentPage,
         rowsPerPage,
+        total,
+        pageCount,
         onCancelUpdateList,
         customUpdateTrigger,
         forceUpdateOnMount,
@@ -128,6 +130,8 @@ export const ListViewUpdater = (props: Props) => {
             sortByDirection={sortByDirection}
             currentPage={computedPage}
             rowsPerPage={rowsPerPage}
+            total={total}
+            pageCount={pageCount}
             ready={!resetMode}
         />
     );

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsBase/ListViewUpdater/listViewUpdater.types.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsBase/ListViewUpdater/listViewUpdater.types.ts
@@ -1,5 +1,5 @@
 import type { Categories, UpdateList } from '../workingListsBase.types';
-import type { FiltersData } from '../../../ListView';
+import type { FiltersData, PagingTotals } from '../../../ListView';
 import type { ListViewLoaderOutputProps } from '../ListViewLoader';
 
 type ExtractedProps = {
@@ -22,7 +22,7 @@ type RestProps = ListViewLoaderOutputProps & OptionalExtractedProps | ExtractedP
 
 export type Props = RestProps & ExtractedProps;
 
-export type ListViewUpdaterOutputProps = RestProps & {
+export type ListViewUpdaterOutputProps = RestProps & PagingTotals & {
     filters: FiltersData,
     sortById: string,
     sortByDirection: string,

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsBase/workingListsBase.types.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsBase/workingListsBase.types.ts
@@ -11,6 +11,7 @@ import type {
     DataSource,
     FiltersData,
     FiltersOnly,
+    PagingTotals,
     RemoveFilter,
     SelectRestMenuItem,
     SelectRow,
@@ -130,7 +131,7 @@ export type ListViewLoaderContextData = {
     viewPreloaded?: boolean,
 };
 
-export type ListViewUpdaterContextData = {
+export type ListViewUpdaterContextData = PagingTotals & {
     currentPage?: number,
     rowsPerPage?: number,
     onCancelUpdateList?: () => void,
@@ -180,7 +181,7 @@ export type SharingSettings = {
 };
 export type SetTemplateSharingSettings = (sharingSettings: SharingSettings, templateId: string) => void;
 
-export type InterfaceProps = Readonly<{
+export type InterfaceProps = Readonly<PagingTotals & {
     categories?: Categories,
     columns: ColumnConfigs,
     currentPage?: number,

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/hooks/useWorkingListsCommonStateManagement.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/hooks/useWorkingListsCommonStateManagement.ts
@@ -153,6 +153,8 @@ const useView = (
         const {
             rowsPerPage,
             currentPage,
+            total,
+            pageCount,
             sortById,
             sortByDirection,
             initial,
@@ -179,6 +181,8 @@ const useView = (
             stickyFilters: workingListsStickyFilters[storeId],
             rowsPerPage: nextRowsPerPage || rowsPerPage,
             currentPage: nextCurrentPage || currentPage,
+            total,
+            pageCount,
             sortById: nextSortById || sortById,
             sortByDirection: nextSortByDirection || sortByDirection,
             initialViewConfig: nextInitial || initial,

--- a/src/core_modules/capture-core/events/eventRequests.ts
+++ b/src/core_modules/capture-core/events/eventRequests.ts
@@ -191,6 +191,8 @@ export async function getEvents(
     const pagingData = {
         rowsPerPage: queryParams.pageSize,
         currentPage: queryParams.page,
+        total: apiResponse?.total ?? null,
+        pageCount: apiResponse?.pageCount ?? null,
     };
 
     return {

--- a/src/core_modules/capture-core/events/eventRequests.ts
+++ b/src/core_modules/capture-core/events/eventRequests.ts
@@ -191,8 +191,8 @@ export async function getEvents(
     const pagingData = {
         rowsPerPage: queryParams.pageSize,
         currentPage: queryParams.page,
-        total: apiResponse?.total ?? null,
-        pageCount: apiResponse?.pageCount ?? null,
+        total: apiResponse?.total ?? apiResponse?.pager?.total ?? null,
+        pageCount: apiResponse?.pageCount ?? apiResponse?.pager?.pageCount ?? null,
     };
 
     return {

--- a/src/core_modules/capture-core/reducers/descriptions/workingLists/meta/meta.reducerDescription.ts
+++ b/src/core_modules/capture-core/reducers/descriptions/workingLists/meta/meta.reducerDescription.ts
@@ -57,11 +57,13 @@ export const workingListsMetaDesc = createReducerDescription({
     [workingListsCommonActionTypes.LIST_UPDATE_SUCCESS]: (state, action) => {
         const newState = { ...state };
         const { storeId, pagingData } = action.payload;
+        const { total, pageCount } = pagingData || {};
         const next = newState[storeId].next;
         newState[storeId] = {
             ...newState[storeId],
             ...next,
-            ...pagingData,
+            total,
+            pageCount,
             filters: {
                 ...newState[storeId].filters,
                 ...newState[storeId].next.filters,

--- a/src/core_modules/capture-core/trackedEntityInstances/trackedEntityInstanceRequests.ts
+++ b/src/core_modules/capture-core/trackedEntityInstances/trackedEntityInstanceRequests.ts
@@ -89,8 +89,8 @@ export async function getTrackedEntityInstances(
     const pagingData = {
         rowsPerPage: queryParams.pageSize,
         currentPage: queryParams.page,
-        total: apiResponse?.total ?? null,
-        pageCount: apiResponse?.pageCount ?? null,
+        total: apiResponse?.total ?? apiResponse?.pager?.total ?? null,
+        pageCount: apiResponse?.pageCount ?? apiResponse?.pager?.pageCount ?? null,
     };
 
     return {

--- a/src/core_modules/capture-core/trackedEntityInstances/trackedEntityInstanceRequests.ts
+++ b/src/core_modules/capture-core/trackedEntityInstances/trackedEntityInstanceRequests.ts
@@ -89,6 +89,8 @@ export async function getTrackedEntityInstances(
     const pagingData = {
         rowsPerPage: queryParams.pageSize,
         currentPage: queryParams.page,
+        total: apiResponse?.total ?? null,
+        pageCount: apiResponse?.pageCount ?? null,
     };
 
     return {

--- a/src/core_modules/capture-ui/Pagination/Pagination.component.tsx
+++ b/src/core_modules/capture-ui/Pagination/Pagination.component.tsx
@@ -7,6 +7,8 @@ type Props = {
     rowsCountSelector?: React.ReactNode | null | undefined;
     rowsCountSelectorLabel?: string | null | undefined;
     navigationElements: React.ReactNode;
+    total?: number | null;
+    pageCount?: number | null;
 };
 
 export class Pagination extends React.Component<Props> {
@@ -39,19 +41,29 @@ export class Pagination extends React.Component<Props> {
             rowsCountSelector,
             rowsCountSelectorLabel,
             navigationElements,
+            total,
+            pageCount,
         } = this.props;
 
         const rowsCountElement = Pagination.getRowsCountElement(rowsCountSelectorLabel, rowsCountSelector);
+        const pageLabel = pageCount != null
+            ? i18n.t('Page {{currentPage}} of {{pageCount}}', { currentPage, pageCount })
+            : i18n.t('Page {{currentPage}}', { currentPage });
         return (
             <div
                 data-test="pagination"
                 className={defaultClasses.pagination}
             >
                 {rowsCountElement}
+                {total != null && (
+                    <div className={defaultClasses.paginationDisplayRowsContainer}>
+                        {i18n.t('{{count}} result', { count: total }) as React.ReactNode}
+                    </div>
+                )}
                 {
                     currentPage &&
                     <div className={defaultClasses.paginationDisplayRowsContainer}>
-                        {i18n.t('Page {{currentPage}}', { currentPage }) as React.ReactNode}
+                        {pageLabel as React.ReactNode}
                     </div>
                 }
                 {navigationElements}


### PR DESCRIPTION
**Task:** https://app.clickup.com/t/869czvm02

## Summary

Adds a total-results count and page-count display to the working-list pagination footer. The footer now shows "N result(s)" and "Page X of Y" next to the existing prev/next controls, both reflecting the current filters.

<img width="488" height="95" alt="imagen" src="https://github.com/user-attachments/assets/3d3c2041-f438-42b9-9b1f-35ec558812d3" />


## Why

Users could navigate pages but had no way to see how many records matched their current program / org unit / filter selection. This surfaces that information using data the DHIS2 tracker API already exposes when asked.

## How

- **API layer** — `tracker/events` and `tracker/trackedEntities` requests now send `totalPages=true`. The response's top-level `total` and `pageCount` are captured in `pagingData` (returned from `getEvents`, `getTrackedEntityInstances`, `getEventListData`, `getTeiListData`).
- **State** — The working-lists meta reducer already spreads `...pagingData` on init success. `LIST_UPDATE_SUCCESS` was tightened to only take `total` and `pageCount` from the server response; `currentPage` / `rowsPerPage` still come from the existing `next` merge, preserving current behavior on page/sort/filter changes. The TEI update epic, which previously dropped `pagingData` entirely, now forwards it.
- **Threading** — `total` and `pageCount` flow through the existing selector → `WorkingListsContextBuilder` → `ListViewUpdaterContext` → `PaginationContext` chain. A shared `PagingTotals` type replaces the per-level inline duplication.
- **Render** — `capture-ui/Pagination` renders the new fields when present. Both are optional; backends that don't return them simply show the old "Page N" output.

## UX decisions

- Single count only: "N results" — reflects whatever is on screen (filtered or unfiltered).
- Count is hidden (not shown as "—") on older DHIS2 backends that don't return `total` / `pageCount`.

## Caveats / things to watch

- **Server cost**: `totalPages=true` triggers a `COUNT(*)` on the tracker query. On large deployments (tens of millions of events) this adds measurable latency to every list load. Worth monitoring after deploy — if it hurts, the natural next step is caching the base total per `(program, orgUnit, filters)` so we only pay the count when filters change.
  - This feature was removed on purpose in 2.36 because of performance issues. See [issue](https://dhis2.atlassian.net/browse/DHIS2-8705?search_id=6a6e59f3-c246-4fe1-8b75-6e358b016b26&referrer=quick-find).
- No unit test changes — the reducer/selector changes are additive and the existing tests pass. Manual smoke-test needed on event + TEI working lists with program/org-unit switches and filter changes.

## Test plan

- [ ] Event working list: footer shows correct total and page count; count updates when filters are applied/cleared
- [ ] Tracker (TEI) working list: same
- [ ] Switching program or org unit refreshes both values
- [ ] Older DHIS2 backend (no `total` in response): footer degrades to the original "Page N" output, no errors
- [ ] Rows-per-page change recomputes page count correctly