### PR TITLE
[SP] [105.13.5] feat: honor TEA read sharing setting in WidgetProfile and Edit form

### DIFF
--- a/src/core_modules/capture-core/components/WidgetProfile/DataEntry/FormFoundation/DataElement.tsx
+++ b/src/core_modules/capture-core/components/WidgetProfile/DataEntry/FormFoundation/DataElement.tsx
@@ -350,6 +350,10 @@ export const buildDataElement = (
         return null;
     }
 
+    if (trackedEntityAttribute.access?.read === false) {
+        return null;
+    }
+
     return trackedEntityAttribute.valueType === dataElementTypes.DATE
         ? buildDateDataElement(optionSets, programTrackedEntityAttribute, trackedEntityAttribute, querySingleResource)
         : buildBaseDataElement(

--- a/src/core_modules/capture-core/components/WidgetProfile/DataEntry/FormFoundation/types.ts
+++ b/src/core_modules/capture-core/components/WidgetProfile/DataEntry/FormFoundation/types.ts
@@ -56,6 +56,9 @@ export type TrackedEntityAttribute = {
     unique?: boolean | null;
     orgunitScope?: boolean | null;
     pattern?: string | null;
+    access?: {
+        read?: boolean | null;
+    } | null;
 };
 
 export type ProgramTrackedEntityAttribute = {

--- a/src/core_modules/capture-core/components/WidgetProfile/hooks/hooks.types.ts
+++ b/src/core_modules/capture-core/components/WidgetProfile/hooks/hooks.types.ts
@@ -31,6 +31,9 @@ export type InputProgramData = {
             };
             valueType: string;
             unique: boolean;
+            access?: {
+                read?: boolean | null;
+            } | null;
         };
         displayInList: boolean;
     }>;

--- a/src/core_modules/capture-core/components/WidgetProfile/hooks/useApiProgram.ts
+++ b/src/core_modules/capture-core/components/WidgetProfile/hooks/useApiProgram.ts
@@ -21,7 +21,7 @@ const fields =
             'options[id,displayName,code,style, translations]]]]],' +
     'programTrackedEntityAttributes[trackedEntityAttribute[id,displayName,displayShortName,displayFormName,' +
         'displayDescription,valueType,optionSetValue,unique,orgunitScope,pattern,translations[property,locale,value],' +
-        'optionSet[id,displayName,version,valueType,options[id,displayName,name,code,style,translations]]],' +
+        'optionSet[id,displayName,version,valueType,options[id,displayName,name,code,style,translations]],access[read]],' +
         'displayInList,searchable,mandatory,renderOptionsAsRadio,allowFutureDate],' +
     'trackedEntityType[id,access,displayName,allowAuditLog,minAttributesRequiredToSearch,featureType,' +
         'trackedEntityTypeAttributes[trackedEntityAttribute[id],displayInList,mandatory,searchable],' +

--- a/src/core_modules/capture-core/components/WidgetProfile/hooks/useClientAttributesWithSubvalues.ts
+++ b/src/core_modules/capture-core/components/WidgetProfile/hooks/useClientAttributesWithSubvalues.ts
@@ -31,8 +31,12 @@ export const useClientAttributesWithSubvalues = (
                 async (promisedAcc: Promise<any[]>, currentTEA) => {
                     const {
                         displayInList,
-                        trackedEntityAttribute: { id, optionSet, valueType, unique, displayFormName },
+                        trackedEntityAttribute: { id, optionSet, valueType, unique, displayFormName, access },
                     } = currentTEA;
+                    const acc = await promisedAcc;
+                    if (access?.read === false) {
+                        return acc;
+                    }
                     const foundAttribute = trackedEntityInstanceAttributes?.find(item => item.attribute === id);
                     let value;
                     if (foundAttribute) {
@@ -51,8 +55,6 @@ export const useClientAttributesWithSubvalues = (
                             value = convertServerToClient(foundAttribute.value, valueType as any);
                         }
                     }
-
-                    const acc = await promisedAcc;
 
                     if (isMultiTextWithoutOptionset(valueType, optionSet)) {
                         log.error(errorCreator(MULIT_TEXT_WITH_NO_OPTIONS_SET)({ optionSet }));


### PR DESCRIPTION
**Task:** https://app.clickup.com/t/869cjkean

**Description:** Port of #6 to v105.13-5

Fetch `access[read]` for `trackedEntityAttributes` and use it to control visibility. Attributes without read access are hidden from both the profile display and the edit form.

Tested create/view/edit with both a user with permissions, and a user without permissions for some TEAs. Previous fix was known to fail with conflict errors upon saving an edit with an unprivileged user, but couldn't reproduce it here.