### PR TITLE
[SP] [105.13.5] fix: WidgetProfile rules engine empty after reopening Edit modal

### DIFF
--- a/src/core_modules/capture-core/components/WidgetProfile/DataEntry/hooks/useProgramRules.ts
+++ b/src/core_modules/capture-core/components/WidgetProfile/DataEntry/hooks/useProgramRules.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState, useEffect } from 'react';
+import { useMemo, useRef, useState, useEffect } from 'react';
 import { useDataQuery } from '@dhis2/app-runtime';
 
 const fields =
@@ -27,16 +27,23 @@ export const useProgramRules = (programId: string) => {
             lazy: true,
         },
     );
+    const lastAppendedDataRef = useRef<any>(null);
     useEffect(() => {
         const hasNextPage = !called || (!loading && (data as any)?.programRules?.pager?.nextPage);
         if (hasNextPage) {
             refetch({ variables: { page: page + 1 } });
             setPage(page + 1);
         }
-        if (data && (data as any).programRules && (data as any).programRules.pager?.total > programRules.length) {
-            setProgramRules([...programRules, ...(data as any).programRules.programRules]);
+        if (
+            data &&
+            data !== lastAppendedDataRef.current &&
+            (data as any).programRules &&
+            (data as any).programRules.programRules
+        ) {
+            lastAppendedDataRef.current = data;
+            setProgramRules(prev => [...prev, ...(data as any).programRules.programRules]);
         }
-    }, [data, called, loading, refetch, setProgramRules, page, programRules]);
+    }, [data, called, loading, refetch, page]);
 
     return {
         error,


### PR DESCRIPTION
**Task:** https://app.clickup.com/t/869czvkrw

## Summary

When the WidgetProfile Edit modal is closed and reopened on the same TEI, the program-rules engine ends up with an empty rules container and returns no effects for any field change — so HIDEFIELD/SHOWFIELD/ASSIGN/etc. silently stop working until the page is reloaded.

The root cause is in `useProgramRules` (`src/core_modules/capture-core/components/WidgetProfile/DataEntry/hooks/useProgramRules.ts`):

- It paginates program rules via lazy `useDataQuery` and accumulates results into a `programRules` state array.
- The fetch effect had `programRules` in its deps and read `programRules.length` to decide whether to append the next page.
- On a re-mount, `useDataQuery` returns its cached `data` reference immediately. The effect then re-runs on every state update with the **same `data`**, appending the same page multiple times. The accumulated length never matches the pager total, so `loading` stays `true` permanently and the rules container is never built.

Fix:

- Track the last appended `data` reference in a `useRef` and only append when it changes — the page only contributes once per fetch, regardless of how many times the effect re-runs.
- Switch to a functional `setProgramRules(prev => [...prev, ...])` updater so `programRules` is no longer needed in the effect's deps.

## Test plan

- [ ] Open a TEI's Edit profile modal in WidgetProfile on a program that has program rules.
- [ ] Verify a HIDEFIELD/SHOWFIELD/ASSIGN rule fires correctly on first open (e.g. change a field that triggers the rule and confirm the effect).
- [ ] Close the modal and reopen it on the same TEI. Verify rule effects still fire — previously the form would behave as if there were no rules.
- [ ] Repeat on a program with many program rules (so pagination kicks in across multiple pages) and confirm all rules are loaded exactly once.
- [ ] Confirm there's no regression on first open: rules still load, `loading` flips to `false`, no duplicate entries in the rules container.