### PR TITLE
[SP] [105.13.5] fix: disable next-page button on the last page

### DIFF
--- a/src/core_modules/capture-core/components/ListView/Pagination/ListPaginationMain.component.tsx
+++ b/src/core_modules/capture-core/components/ListView/Pagination/ListPaginationMain.component.tsx
@@ -21,11 +21,24 @@ type PaginationWrappedProps = PagingTotals & {
 const PaginationWrapped: React.ComponentType<PaginationWrappedProps> =
     withRowsPerPageSelector()(withNavigation()(Pagination)) as any;
 
-export const ListPaginationMain = ({ rowCountPage, rowsPerPage, ...passOnProps }: Props) => (
-    <PaginationWrapped
-        {...passOnProps}
-        rowsPerPage={rowsPerPage}
-        rowsCountSelectorLabel={i18n.t('Rows per page')}
-        nextPageButtonDisabled={!!(rowsPerPage > rowCountPage)}
-    />
-);
+export const ListPaginationMain = ({
+    rowCountPage,
+    rowsPerPage,
+    currentPage,
+    pageCount,
+    ...passOnProps
+}: Props) => {
+    const nextPageButtonDisabled = typeof pageCount === 'number'
+        ? currentPage >= pageCount
+        : rowsPerPage > rowCountPage;
+    return (
+        <PaginationWrapped
+            {...passOnProps}
+            currentPage={currentPage}
+            pageCount={pageCount}
+            rowsPerPage={rowsPerPage}
+            rowsCountSelectorLabel={i18n.t('Rows per page')}
+            nextPageButtonDisabled={nextPageButtonDisabled}
+        />
+    );
+};


### PR DESCRIPTION
**Task:** https://app.clickup.com/t/869czvkrw

## Summary

The next-page button stays enabled on a full last page (e.g. 75 results / 15 per page), so users can click past the end into an empty page. The faulty heuristic (`rowsPerPage > rowCountPage`) predates #8, but #8 made it visible by adding the "Page X of Y" label. Users were seeing "Page 6 of 5" before the button disables.

Now that the backend returns `pageCount`, prefer `currentPage >= pageCount` and fall back to the heuristic only when
`pageCount` is unavailable.

<img width="483" height="71" alt="imagen" src="https://github.com/user-attachments/assets/719b930c-0359-4c3a-834a-304bbd13e3f7" />

## Test plan

- [x] Open a working list with a total that is an exact multiple of the page size (e.g. 75 / 15). On the last page, the next-page button is disabled.
- [x] Open a working list whose last page is partial (e.g. 73 / 15). Last page still disables next correctly.
- [x] Navigate forward/back across pages — counts and "Page X of Y" stay consistent.